### PR TITLE
chore: skip CI and code review checks on draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   python:
     name: Python (lint + typecheck)
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -39,6 +41,7 @@ jobs:
 
   frontend:
     name: Frontend (lint + typecheck)
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,8 +7,9 @@ on:
 jobs:
   claude-review:
     if: |
-      github.event.pull_request.user.login != 'renovate[bot]' ||
-      contains(toJSON(github.event.pull_request.labels.*.name), 'major-update')
+      github.event.pull_request.draft == false &&
+      (github.event.pull_request.user.login != 'renovate[bot]' ||
+      contains(toJSON(github.event.pull_request.labels.*.name), 'major-update'))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- `ci.yml`: adds `ready_for_review` to `pull_request` types and `if: draft == false` to both jobs — CI now skips draft PRs and fires once when promoted to ready.
- `claude-code-review.yml`: adds `draft == false` to the existing job condition — already had `ready_for_review` in trigger types, so no trigger change needed.

## Behavior after this change
| Event | CI | Claude Review |
|---|---|---|
| Draft PR opened | skipped | skipped |
| Push to draft PR | skipped | skipped |
| Marked ready for review | runs | runs |
| Push to ready PR | runs | runs |

## Test plan
- [ ] Open a draft PR and verify no checks trigger
- [ ] Mark it ready for review and verify all checks run